### PR TITLE
Add react router and basic config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,13 @@
         "@micro-stacks/client": "1.0.0",
         "@micro-stacks/react": "1.0.0",
         "itty-router": "^3.0.11",
+        "localforage": "^1.10.0",
+        "match-sorter": "^6.3.1",
         "micro-stacks": "^1.0.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.7.0",
+        "sort-by": "^1.2.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20221111.1",
@@ -392,6 +396,17 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
+      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
@@ -624,6 +639,14 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.0.tgz",
+      "integrity": "sha512-nwQoYb3m4DDpHTeOwpJEuDt8lWVcujhYYSFGLluC+9es2PyLjm+jjq3IeRBQbwBtPLJE/lkuHuGHr8uQLgmJRA==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@stacks/stacks-blockchain-api-types": {
       "version": "6.3.2",
@@ -1243,6 +1266,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/is-core-module": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
@@ -1289,6 +1317,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1319,6 +1363,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
       }
     },
     "node_modules/micro-stacks": {
@@ -1368,6 +1421,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "dev": true
+    },
+    "node_modules/object-path": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.6.0.tgz",
+      "integrity": "sha512-fxrwsCFi3/p+LeLOAwo/wyRMODZxdGBtUlWRzsEpsUVrisZbEfZ21arxLGfaWfcnqb8oHPNihIb4XPE8CQPN5A==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
@@ -1449,6 +1510,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.7.0.tgz",
+      "integrity": "sha512-KNWlG622ddq29MAM159uUsNMdbX8USruoKnwMMQcs/QWZgFUayICSn2oB7reHce1zPj6CG18kfkZIunSSRyGHg==",
+      "dependencies": {
+        "@remix-run/router": "1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.7.0.tgz",
+      "integrity": "sha512-jQtXUJyhso3kFw430+0SPCbmCmY1/kJv8iRffGHwHy3CkoomGxeYzMkmeSPYo6Egzh3FKJZRAL22yg5p2tXtfg==",
+      "dependencies": {
+        "@remix-run/router": "1.3.0",
+        "react-router": "6.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -1496,6 +1597,14 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/sort-by": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sort-by/-/sort-by-1.2.0.tgz",
+      "integrity": "sha512-aRyW65r3xMnf4nxJRluCg0H/woJpksU1dQxRtXYzau30sNBOmf5HACpDd9MZDhKh7ALQ5FgSOfMPwZEtUmMqcg==",
+      "dependencies": {
+        "object-path": "0.6.0"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,13 @@
     "@micro-stacks/client": "1.0.0",
     "@micro-stacks/react": "1.0.0",
     "itty-router": "^3.0.11",
+    "localforage": "^1.10.0",
+    "match-sorter": "^6.3.1",
     "micro-stacks": "^1.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.7.0",
+    "sort-by": "^1.2.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20221111.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,7 @@
 import './App.css';
 import ccLogo from './assets/citycoins.png';
 import * as MicroStacks from '@micro-stacks/react';
-import { WalletConnectButton } from './components/wallet-connect-button';
-import { UserCard } from './components/user-card';
-
-function Contents() {
-  return (
-    <div>
-      <img src={ccLogo} alt="logo test" />
-      <h1>micro-stacks + Vite + React</h1>
-      <div className="card">
-        <UserCard />
-        <WalletConnectButton />
-        <p
-          style={{
-            display: 'block',
-            marginTop: '40px',
-          }}
-        >
-          Edit <code>src/app.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the micro-stacks, Vite, and React logos to learn more
-      </p>
-      <a href="openapi.yml" download >OpenAPI Docs?</a>
-    </div>
-  );
-}
+import RootIndex from './routes/root-index';
 
 export default function App() {
   return (
@@ -35,7 +9,7 @@ export default function App() {
       appName={'CityCoins Protocol API'}
       appIconUrl={ccLogo}
     >
-      <Contents />
+      <RootIndex />
     </MicroStacks.ClientProvider>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,41 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import App from './App'
 import './index.css'
+import NotFound from './routes/not-found';
+import TestRoute from './routes/test-route';
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <App />,
+    errorElement: <NotFound />
+  },
+  {
+    path: "/activation",
+    element: <TestRoute />
+  },
+  {
+    path: "/dashboard",
+    element: <TestRoute />
+  },
+  {
+    path: "/mining",
+    element: <TestRoute />
+  },
+  {
+    path: "/stacking",
+    element: <TestRoute />
+  },
+  {
+    path: "/tools",
+    element: <TestRoute />
+  },
+]);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>
 )

--- a/src/routes/not-found.tsx
+++ b/src/routes/not-found.tsx
@@ -1,0 +1,10 @@
+import Navigation from './root-navigation';
+
+export default function NotFound() {
+  return (
+    <div>
+      <h1>404 - Not Found</h1>
+      <Navigation />
+    </div>
+  );
+}

--- a/src/routes/root-index.tsx
+++ b/src/routes/root-index.tsx
@@ -1,0 +1,38 @@
+import { UserCard } from '../components/user-card';
+import { WalletConnectButton } from '../components/wallet-connect-button';
+import ccLogo from '../assets/citycoins.png';
+import Navigation from './root-navigation';
+
+export default function RootIndex() {
+  return (
+    <div>
+      <img
+        src={ccLogo}
+        alt="logo test"
+      />
+      <h1>micro-stacks + Vite + React</h1>
+      <div className="card">
+        <UserCard />
+        <WalletConnectButton />
+        <p
+          style={{
+            display: 'block',
+            marginTop: '40px',
+          }}
+        >
+          Edit <code>src/app.jsx</code> and save to test HMR
+        </p>
+      </div>
+      <p className="read-the-docs">
+        Click on the micro-stacks, Vite, and React logos to learn more
+      </p>
+      <a
+        href="openapi.yml"
+        download
+      >
+        OpenAPI Docs?
+      </a>
+      <Navigation />
+    </div>
+  );
+}

--- a/src/routes/root-navigation.tsx
+++ b/src/routes/root-navigation.tsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom';
+
+export default function Navigation() {
+  return (
+    <nav>
+      <ul>
+        <li>
+          <Link to="/">Home</Link>
+        </li>
+        <li>
+          <Link to="/activation">Activation</Link>
+        </li>
+        <li>
+          <Link to="/dashboard">Dashboard</Link>
+        </li>
+        <li>
+          <Link to="/mining">Mining</Link>
+        </li>
+        <li>
+          <Link to="/stacking">Stacking</Link>
+        </li>
+        <li>
+          <Link to="/tools">Tools</Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/routes/test-route.tsx
+++ b/src/routes/test-route.tsx
@@ -1,0 +1,14 @@
+import { useLocation } from 'react-router-dom';
+import Navigation from './root-navigation';
+
+export default function TestRoute() {
+  const location = useLocation();
+
+  return (
+    <div>
+      <h1>Testing Routes</h1>
+      <p>Current location: {location.pathname}</p>
+      <Navigation />
+    </div>
+  );
+}


### PR DESCRIPTION
This might be an easy way to have both the API and UI in the same instance.

The API endpoints will be needed either way, but this branch proves out that we can have:

- the API served by Pages Functions for anything that matches `/api/*`
  - uses the itty-router under the hood to match and return responses
  - handlers can be separated into components (same as before)
- any other request is served through the web app using react router
  - non-matching routes are served a 404
  - matching routes are served a component
  - pages would be stored under `/routes` in this model