### PR TITLE
Use createResponse helper to generate responses

### DIFF
--- a/functions/api/[[catchall]].ts
+++ b/functions/api/[[catchall]].ts
@@ -1,21 +1,9 @@
-export {};
+import { createResponse } from '../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
-  const requestUrl = new URL(context.request.url);
-  const requestPath = requestUrl.pathname;
-  const requestParams = Array.from(requestUrl.searchParams.entries());
-
-  return new Response(
-    JSON.stringify(
-      {
-        functionPath: context.functionPath,
-        requestPath: requestPath,
-        requestParams: requestParams,
-        message: `Welcome to the CityCoins API! Endpoints match the DAO contract names and function definitions. More info in the project readme: https://github.com/citycoins/protocol-api`,
-      },
-      null,
-      2
-    )
+  return createResponse(
+    `Welcome to the CityCoins API! Endpoints match the DAO contract names and function definitions. More info in the project readme: https://github.com/citycoins/protocol-api`,
+    404
   );
 }

--- a/functions/api/base-dao/executed-at.ts
+++ b/functions/api/base-dao/executed-at.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { principalCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const proposal = requestUrl.searchParams.get('proposal');
-  if (!proposal) return new Response('Missing proposal parameter', { status: 400 });
+  if (!proposal) return createResponse('Missing proposal parameter', 400);
 
   // get result from contract
   const executed = await executedAt(proposal);
 
   // return result
-  if (!executed) return new Response(`Proposal not found: ${proposal}`, { status: 404 });
-  return new Response(JSON.stringify(executed));
+  if (!executed) return createResponse(`Proposal not found: ${proposal}`, 404);
+  return createResponse(executed);
 }
 
 // returns the block height a proposal was executed at

--- a/functions/api/base-dao/is-extension.ts
+++ b/functions/api/base-dao/is-extension.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { principalCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const proposal = requestUrl.searchParams.get('extension');
-  if (!proposal) return new Response('Missing extension parameter', { status: 400 });
+  if (!proposal) return createResponse('Missing extension parameter', 400);
 
   // get result from contract
   const extension = await isExtension(proposal);
 
   // return result
-  if (extension === null) return new Response(`Extension not found: ${proposal}`, { status: 404 });
-  return new Response(JSON.stringify(extension));
+  if (extension === null) return createResponse(`Extension not found: ${proposal}`, 404);
+  return createResponse(extension);
 }
 
 // returns true or false if the contract is an active extension

--- a/functions/api/base-dao/is-extension.ts
+++ b/functions/api/base-dao/is-extension.ts
@@ -30,7 +30,7 @@ async function isExtension(proposal: string) {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd001-direct-execute/get-signals-required.ts
+++ b/functions/api/ccd001-direct-execute/get-signals-required.ts
@@ -1,5 +1,5 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(): Promise<Response> {
@@ -7,8 +7,8 @@ export async function onRequest(): Promise<Response> {
   const signalsRequired = await getSignalsRequired();
 
   // return result
-  if (!signalsRequired) return new Response('Error fetching signals required', { status: 500 });
-  return new Response(JSON.stringify(signalsRequired));
+  if (!signalsRequired) return createResponse('Signals required not found', 404);
+  return createResponse(signalsRequired);
 }
 
 // returns signals required in ccd001-direct-execute

--- a/functions/api/ccd001-direct-execute/get-signals.ts
+++ b/functions/api/ccd001-direct-execute/get-signals.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { principalCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const proposal = requestUrl.searchParams.get('proposal');
-  if (!proposal) return new Response('Missing proposal parameter', { status: 400 });
+  if (!proposal) return createResponse('Missing proposal parameter', 400);
 
   // get result from contract
   const signals = await getSignals(proposal);
 
   // return result
-  if (!signals) return new Response(`Proposal not found: ${proposal}`, { status: 404 });
-  return new Response(JSON.stringify(signals));
+  if (!signals) return createResponse(`Proposal not found: ${proposal}`, 404);
+  return createResponse(signals);
 }
 
 // returns the number of signals for a proposal

--- a/functions/api/ccd001-direct-execute/has-signalled.ts
+++ b/functions/api/ccd001-direct-execute/has-signalled.ts
@@ -1,22 +1,22 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { principalCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const proposal = requestUrl.searchParams.get('proposal');
-  if (!proposal) return new Response('Missing proposal parameter', { status: 400 });
+  if (!proposal) return createResponse('Missing proposal parameter', 400);
   const who = requestUrl.searchParams.get('who');
-  if (!who) return new Response('Missing who parameter', { status: 400 });
+  if (!who) return createResponse('Missing who parameter', 400);
 
   // get result from contract
   const signalled = await hasSignalled(proposal, who);
 
   // return result
-  if (signalled === null) return new Response(`Proposal not found: ${proposal}`, { status: 404 });
-  return new Response(JSON.stringify(signalled));
+  if (signalled === null) return createResponse(`Proposal not found: ${proposal} ${who}`, 404);
+  return createResponse(signalled);
 }
 
 // returns if a given principal has signalled for a proposal

--- a/functions/api/ccd001-direct-execute/has-signalled.ts
+++ b/functions/api/ccd001-direct-execute/has-signalled.ts
@@ -32,7 +32,7 @@ async function hasSignalled(proposal: string, who: string) {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd001-direct-execute/is-approver.ts
+++ b/functions/api/ccd001-direct-execute/is-approver.ts
@@ -30,7 +30,7 @@ async function isApprover(who: string) {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd001-direct-execute/is-approver.ts
+++ b/functions/api/ccd001-direct-execute/is-approver.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { principalCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const who = requestUrl.searchParams.get('who');
-  if (!who) return new Response('Missing who parameter', { status: 400 });
+  if (!who) return createResponse('Missing who parameter', 400);
 
   // get result from contract
   const approver = await isApprover(who);
 
   // return result
-  if (approver === null) return new Response(`Approver not found: ${who}`, { status: 404 });
-  return new Response(JSON.stringify(approver));
+  if (approver === null) return createResponse(`Approver not found: ${who}`, 404);
+  return createResponse(approver);
 }
 
 // returns true or false if the principal is an approver

--- a/functions/api/ccd002-treasury/get-allowed-asset.ts
+++ b/functions/api/ccd002-treasury/get-allowed-asset.ts
@@ -1,21 +1,26 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { principalCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const contractName = requestUrl.searchParams.get('contractName');
-  if (!contractName) return new Response('Missing contractName parameter', { status: 400 });
+  if (!contractName) return createResponse('Missing contractName parameter', 400);
   const assetContract = requestUrl.searchParams.get('assetContract');
-  if (!assetContract) return new Response('Missing assetContract parameter', { status: 400 });
+  if (!assetContract) return createResponse('Missing assetContract parameter', 400);
 
   // get result from contract
   const allowed = await getAllowedAsset(contractName, assetContract);
   // return result
+<<<<<<< HEAD
   if (allowed === null) return new Response(`Asset status not found: ${contractName} ${assetContract}`, { status: 404 });
   return new Response(JSON.stringify(allowed));
+=======
+  if (allowed === undefined) return createResponse(`Asset status not found: ${contractName} ${assetContract}`, 404);
+  return createResponse(allowed);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the asset is allowed in the given treasury contract

--- a/functions/api/ccd002-treasury/get-allowed-asset.ts
+++ b/functions/api/ccd002-treasury/get-allowed-asset.ts
@@ -14,13 +14,8 @@ export async function onRequest(context: any): Promise<Response> {
   // get result from contract
   const allowed = await getAllowedAsset(contractName, assetContract);
   // return result
-<<<<<<< HEAD
-  if (allowed === null) return new Response(`Asset status not found: ${contractName} ${assetContract}`, { status: 404 });
-  return new Response(JSON.stringify(allowed));
-=======
-  if (allowed === undefined) return createResponse(`Asset status not found: ${contractName} ${assetContract}`, 404);
+  if (allowed === null) return createResponse(`Asset status not found: ${contractName} ${assetContract}`, 404);
   return createResponse(allowed);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the asset is allowed in the given treasury contract

--- a/functions/api/ccd002-treasury/get-allowed-asset.ts
+++ b/functions/api/ccd002-treasury/get-allowed-asset.ts
@@ -31,7 +31,7 @@ async function getAllowedAsset(contractName: string, assetContract: string) {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd002-treasury/get-balance-stx.ts
+++ b/functions/api/ccd002-treasury/get-balance-stx.ts
@@ -1,20 +1,25 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const contractName = requestUrl.searchParams.get('contractName');
-  if (!contractName) return new Response('Missing contractName parameter', { status: 400 });
+  if (!contractName) return createResponse('Missing contractName parameter', 400);
 
   // get result from contract
   console.log(`contractName: ${contractName}`);
   const balance = await getBalanceStx(contractName);
 
   // return result
+<<<<<<< HEAD
   if (balance === null) return new Response(`Balance not found: ${contractName}`, { status: 404 });
   return new Response(JSON.stringify(balance));
+=======
+  if (balance === undefined) return createResponse(`Balance not found: ${contractName}`, 404);
+  return createResponse(balance);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns the balance of the treasury contract

--- a/functions/api/ccd002-treasury/get-balance-stx.ts
+++ b/functions/api/ccd002-treasury/get-balance-stx.ts
@@ -13,13 +13,8 @@ export async function onRequest(context: any): Promise<Response> {
   const balance = await getBalanceStx(contractName);
 
   // return result
-<<<<<<< HEAD
-  if (balance === null) return new Response(`Balance not found: ${contractName}`, { status: 404 });
-  return new Response(JSON.stringify(balance));
-=======
-  if (balance === undefined) return createResponse(`Balance not found: ${contractName}`, 404);
+  if (balance === null) return createResponse(`Balance not found: ${contractName}`, 404);
   return createResponse(balance);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns the balance of the treasury contract

--- a/functions/api/ccd002-treasury/is-allowed.ts
+++ b/functions/api/ccd002-treasury/is-allowed.ts
@@ -32,7 +32,7 @@ async function isAllowed(contractName: string, assetContract: string) {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd002-treasury/is-allowed.ts
+++ b/functions/api/ccd002-treasury/is-allowed.ts
@@ -1,22 +1,27 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { principalCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const contractName = requestUrl.searchParams.get('contractName');
-  if (!contractName) return new Response('Missing contractName parameter', { status: 400 });
+  if (!contractName) return createResponse('Missing contractName parameter', 400);
   const assetContract = requestUrl.searchParams.get('assetContract');
-  if (!assetContract) return new Response('Missing assetContract parameter', { status: 400 });
+  if (!assetContract) return createResponse('Missing assetContract parameter', 400);
 
   // get result from contract
   const allowed = await isAllowed(contractName, assetContract);
 
   // return result
+<<<<<<< HEAD
   if (allowed === null) return new Response(`Asset status not found: ${contractName} ${assetContract}`, { status: 404 });
   return new Response(JSON.stringify(allowed));
+=======
+  if (allowed === undefined) return createResponse(`Asset status not found: ${contractName} ${assetContract}`, 404);
+  return createResponse(allowed);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the asset is allowed in the given treasury contract

--- a/functions/api/ccd002-treasury/is-allowed.ts
+++ b/functions/api/ccd002-treasury/is-allowed.ts
@@ -15,13 +15,8 @@ export async function onRequest(context: any): Promise<Response> {
   const allowed = await isAllowed(contractName, assetContract);
 
   // return result
-<<<<<<< HEAD
-  if (allowed === null) return new Response(`Asset status not found: ${contractName} ${assetContract}`, { status: 404 });
-  return new Response(JSON.stringify(allowed));
-=======
-  if (allowed === undefined) return createResponse(`Asset status not found: ${contractName} ${assetContract}`, 404);
+  if (allowed === null) return createResponse(`Asset status not found: ${contractName} ${assetContract}`, 404);
   return createResponse(allowed);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the asset is allowed in the given treasury contract

--- a/functions/api/ccd003-user-registry/get-user-id.ts
+++ b/functions/api/ccd003-user-registry/get-user-id.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { principalCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const user = requestUrl.searchParams.get('user');
-  if (!user) return new Response('Missing user parameter', { status: 400 });
+  if (!user) return createResponse('Missing user parameter', 400);
 
   // get result from contract
   const userId = await getUserId(user);
 
   // return result
-  if (!userId) return new Response(`User ID not found: ${user}`, { status: 404 });
-  return new Response(JSON.stringify(userId));
+  if (!userId) return createResponse(`User ID not found: ${user}`, 404);
+  return createResponse(userId);
 }
 
 async function getUserId(user: string) {

--- a/functions/api/ccd003-user-registry/get-user.ts
+++ b/functions/api/ccd003-user-registry/get-user.ts
@@ -1,20 +1,25 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const userId = requestUrl.searchParams.get('userId');
-  if (!userId) return new Response('Missing userId parameter', { status: 400 });
+  if (!userId) return createResponse('Missing userId parameter', 400);
 
   // get result from contract
   const user = await getUser(userId);
 
   // return result
+<<<<<<< HEAD
   if (!user) return new Response(`User not found: ${userId}`, { status: 404 });
   return new Response(user);
+=======
+  if (!user) return createResponse(`User not found: ${userId}`, 404);
+  return createResponse(user);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 async function getUser(userId: string) {

--- a/functions/api/ccd003-user-registry/get-user.ts
+++ b/functions/api/ccd003-user-registry/get-user.ts
@@ -13,13 +13,8 @@ export async function onRequest(context: any): Promise<Response> {
   const user = await getUser(userId);
 
   // return result
-<<<<<<< HEAD
-  if (!user) return new Response(`User not found: ${userId}`, { status: 404 });
-  return new Response(user);
-=======
   if (!user) return createResponse(`User not found: ${userId}`, 404);
   return createResponse(user);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 async function getUser(userId: string) {

--- a/functions/api/ccd004-city-registry/get-city-id.ts
+++ b/functions/api/ccd004-city-registry/get-city-id.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { stringAsciiCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityName = requestUrl.searchParams.get('cityName');
-  if (!cityName) return new Response('Missing cityName parameter', { status: 400 });
+  if (!cityName) return createResponse('Missing cityName parameter', 400);
 
   // get result from contract
   const cityId = await getCityId(cityName);
 
   // return result
-  if (!cityId) return new Response(`City ID not found: ${cityName}`, { status: 404 });
-  return new Response(JSON.stringify(cityId));
+  if (!cityId) return createResponse(`City ID not found: ${cityName}`, 404);
+  return createResponse(cityId);
 }
 
 async function getCityId(cityName: string) {

--- a/functions/api/ccd004-city-registry/get-city-name.ts
+++ b/functions/api/ccd004-city-registry/get-city-name.ts
@@ -1,20 +1,25 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
 
   // get result from contract
   const cityName = await getCityName(cityId);
 
   // return result
+<<<<<<< HEAD
   if (!cityName) return new Response(`City name not found: ${cityId}`, { status: 404 });
   return new Response(cityName);
+=======
+  if (!cityName) return createResponse(`City name not found: ${cityId}`, 404);
+  return createResponse(cityName);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 async function getCityName(cityId: string) {

--- a/functions/api/ccd004-city-registry/get-city-name.ts
+++ b/functions/api/ccd004-city-registry/get-city-name.ts
@@ -13,13 +13,8 @@ export async function onRequest(context: any): Promise<Response> {
   const cityName = await getCityName(cityId);
 
   // return result
-<<<<<<< HEAD
-  if (!cityName) return new Response(`City name not found: ${cityId}`, { status: 404 });
-  return new Response(cityName);
-=======
   if (!cityName) return createResponse(`City name not found: ${cityId}`, 404);
   return createResponse(cityName);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 async function getCityName(cityId: string) {

--- a/functions/api/ccd005-city-data/get-activation-details.ts
+++ b/functions/api/ccd005-city-data/get-activation-details.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { ActivationDetails, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { ActivationDetails, createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
 
   // get result from contract
   const activationDetails = await getActivationDetails(cityId);
 
   // return result
-  if (!activationDetails) return new Response(`Activation details not found: ${cityId}`, { status: 404 });
-  return new Response(JSON.stringify(activationDetails));
+  if (!activationDetails) return createResponse(`Activation details not found: ${cityId}`, 404);
+  return createResponse(activationDetails);
 }
 
 // returns the activation detials for a given city id

--- a/functions/api/ccd005-city-data/get-city-info.ts
+++ b/functions/api/ccd005-city-data/get-city-info.ts
@@ -1,22 +1,22 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { stringAsciiCV, uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, GetCityInfo, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, GetCityInfo, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const treasuryName = requestUrl.searchParams.get('treasuryName');
-  if (!treasuryName) return new Response('Missing treasuryName parameter', { status: 400 });
+  if (!treasuryName) return createResponse('Missing treasuryName parameter', 400);
 
   // get result from contract
   const cityInfo = await getCityInfo(cityId, treasuryName);
 
   // return result
-  if (!cityInfo) return new Response(`City info not found: ${cityId} ${treasuryName}`, { status: 404 });
-  return new Response(JSON.stringify(cityInfo));
+  if (!cityInfo) return createResponse(`City info not found: ${cityId} ${treasuryName}`, 404);
+  return createResponse(cityInfo);
 }
 
 // returns the city info for a given city ID and treasury name

--- a/functions/api/ccd005-city-data/get-coinbase-info.ts
+++ b/functions/api/ccd005-city-data/get-coinbase-info.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, GetCoinbaseInfo, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, GetCoinbaseInfo, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
 
   // get result from contract
   const coinbaseInfo = await getCoinbaseInfo(cityId);
 
   // return result
-  if (!coinbaseInfo) return new Response(`Coinbase info not found: ${cityId}`, { status: 404 });
-  return new Response(JSON.stringify(coinbaseInfo));
+  if (!coinbaseInfo) return createResponse(`Coinbase info not found: ${cityId}`, 404);
+  return createResponse(coinbaseInfo);
 }
 
 // returns the coinbase info for a given city ID

--- a/functions/api/ccd005-city-data/get-treasury-address.ts
+++ b/functions/api/ccd005-city-data/get-treasury-address.ts
@@ -1,22 +1,22 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const treasuryId = requestUrl.searchParams.get('treasuryId');
-  if (!treasuryId) return new Response('Missing treasuryId parameter', { status: 400 });
+  if (!treasuryId) return createResponse('Missing treasuryId parameter', 400);
 
   // get result from contract
   const treasuryAddress = await getTreasuryAddress(cityId, treasuryId);
 
   // return result
-  if (!treasuryAddress) return new Response(`Treasury address not found: ${cityId} ${treasuryId}`, { status: 404 });
-  return new Response(JSON.stringify(treasuryId));
+  if (!treasuryAddress) return createResponse(`Treasury address not found: ${cityId} ${treasuryId}`, 404);
+  return createResponse(treasuryId);
 }
 
 // returns the treasury address for a given city ID and treasury ID

--- a/functions/api/ccd005-city-data/get-treasury-by-name.ts
+++ b/functions/api/ccd005-city-data/get-treasury-by-name.ts
@@ -15,13 +15,8 @@ export async function onRequest(context: any): Promise<Response> {
   const treasuryAddress = await getTreasuryByName(Number(cityId), treasuryName);
 
   // return result
-<<<<<<< HEAD
-  if (!treasuryAddress) return new Response(`Treasury address not found: ${cityId} ${treasuryName}`, { status: 404 });
-  return new Response(treasuryAddress);
-=======
   if (!treasuryAddress) return createResponse(`Treasury address not found: ${cityId} ${treasuryName}`, 404);
   return createResponse(treasuryAddress);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns the treasury address for a given city ID and treasury name

--- a/functions/api/ccd005-city-data/get-treasury-by-name.ts
+++ b/functions/api/ccd005-city-data/get-treasury-by-name.ts
@@ -1,22 +1,27 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { stringAsciiCV, uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const treasuryName = requestUrl.searchParams.get('treasuryName');
-  if (!treasuryName) return new Response('Missing treasuryName parameter', { status: 400 });
+  if (!treasuryName) return createResponse('Missing treasuryName parameter', 400);
 
   // get result from contract
   const treasuryAddress = await getTreasuryByName(Number(cityId), treasuryName);
 
   // return result
+<<<<<<< HEAD
   if (!treasuryAddress) return new Response(`Treasury address not found: ${cityId} ${treasuryName}`, { status: 404 });
   return new Response(treasuryAddress);
+=======
+  if (!treasuryAddress) return createResponse(`Treasury address not found: ${cityId} ${treasuryName}`, 404);
+  return createResponse(treasuryAddress);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns the treasury address for a given city ID and treasury name

--- a/functions/api/ccd005-city-data/get-treasury-id.ts
+++ b/functions/api/ccd005-city-data/get-treasury-id.ts
@@ -1,22 +1,22 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { stringAsciiCV, uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const treasuryName = requestUrl.searchParams.get('treasuryName');
-  if (!treasuryName) return new Response('Missing treasuryName parameter', { status: 400 });
+  if (!treasuryName) return createResponse('Missing treasuryName parameter', 400);
 
   // get result from contract
   const treasuryId = await getTreasuryId(cityId, treasuryName);
 
   // return result
-  if (!treasuryId) return new Response(`Treasury ID not found: ${cityId} ${treasuryName}`, { status: 404 });
-  return new Response(JSON.stringify(treasuryId));
+  if (!treasuryId) return createResponse(`Treasury ID not found: ${cityId} ${treasuryName}`, 404);
+  return createResponse(treasuryId);
 }
 
 async function getTreasuryId(cityId: string, treasuryName: string) {

--- a/functions/api/ccd005-city-data/get-treasury-name.ts
+++ b/functions/api/ccd005-city-data/get-treasury-name.ts
@@ -15,13 +15,8 @@ export async function onRequest(context: any): Promise<Response> {
   const treasuryName = await getTreasuryName(cityId, treasuryId);
 
   // return result
-<<<<<<< HEAD
-  if (!treasuryName) return new Response(`Treasury name not found: ${cityId} ${treasuryId}`, { status: 404 });
-  return new Response(treasuryName);
-=======
   if (!treasuryName) return createResponse(`Treasury name not found: ${cityId} ${treasuryId}`, 404);
-  return createResponse('Not implemented, coming soon!', 501);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
+  return createResponse(treasuryName);
 }
 
 async function getTreasuryName(cityId: string, treasuryId: string) {

--- a/functions/api/ccd005-city-data/get-treasury-name.ts
+++ b/functions/api/ccd005-city-data/get-treasury-name.ts
@@ -1,22 +1,27 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const treasuryId = requestUrl.searchParams.get('treasuryId');
-  if (!treasuryId) return new Response('Missing treasuryId parameter', { status: 400 });
+  if (!treasuryId) return createResponse('Missing treasuryId parameter', 400);
 
   // get result from contract
   const treasuryName = await getTreasuryName(cityId, treasuryId);
 
   // return result
+<<<<<<< HEAD
   if (!treasuryName) return new Response(`Treasury name not found: ${cityId} ${treasuryId}`, { status: 404 });
   return new Response(treasuryName);
+=======
+  if (!treasuryName) return createResponse(`Treasury name not found: ${cityId} ${treasuryId}`, 404);
+  return createResponse('Not implemented, coming soon!', 501);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 async function getTreasuryName(cityId: string, treasuryId: string) {

--- a/functions/api/ccd005-city-data/get-treasury-nonce.ts
+++ b/functions/api/ccd005-city-data/get-treasury-nonce.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
 
   // get result from contract
   const treasuryNonce = await getTreasuryNonce(cityId);
 
   // return result
-  if (!treasuryNonce) return new Response(`Treasury nonce not found: ${cityId}`, { status: 404 });
-  return new Response(JSON.stringify(treasuryNonce));
+  if (!treasuryNonce) return createResponse(`Treasury nonce not found: ${cityId}`, 404);
+  return createResponse(treasuryNonce);
 }
 
 async function getTreasuryNonce(cityId: string) {

--- a/functions/api/ccd005-city-data/is-city-activated.ts
+++ b/functions/api/ccd005-city-data/is-city-activated.ts
@@ -1,19 +1,24 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
 
   // get result from contract
   const activated = await isCityActivated(cityId);
 
   // return result
+<<<<<<< HEAD
   if (activated === null) return new Response(`City not found: ${cityId}`, { status: 404 });
   return new Response(JSON.stringify(activated));
+=======
+  if (activated === undefined) return createResponse(`City activation status not found: ${cityId}`, 404);
+  return createResponse(activated);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 async function isCityActivated(cityId: string) {

--- a/functions/api/ccd005-city-data/is-city-activated.ts
+++ b/functions/api/ccd005-city-data/is-city-activated.ts
@@ -12,13 +12,8 @@ export async function onRequest(context: any): Promise<Response> {
   const activated = await isCityActivated(cityId);
 
   // return result
-<<<<<<< HEAD
-  if (activated === null) return new Response(`City not found: ${cityId}`, { status: 404 });
-  return new Response(JSON.stringify(activated));
-=======
-  if (activated === undefined) return createResponse(`City activation status not found: ${cityId}`, 404);
+  if (activated === null) return createResponse(`City activation status not found: ${cityId}`, 404);
   return createResponse(activated);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 async function isCityActivated(cityId: string) {

--- a/functions/api/ccd005-city-data/is-city-activated.ts
+++ b/functions/api/ccd005-city-data/is-city-activated.ts
@@ -1,4 +1,5 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
+import { uintCV } from 'micro-stacks/clarity';
 import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
@@ -23,12 +24,12 @@ async function isCityActivated(cityId: string) {
         contractAddress: DEPLOYER('mainnet'),
         contractName: 'ccd005-city-data',
         functionName: 'is-city-activated',
-        functionArgs: [],
+        functionArgs: [uintCV(Number(cityId))],
         network: NETWORK('mainnet'),
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd006-citycoin-mining/get-block-winner.ts
+++ b/functions/api/ccd006-citycoin-mining/get-block-winner.ts
@@ -32,7 +32,7 @@ async function getBlockWinner(cityId: string, height: string) {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd006-citycoin-mining/get-block-winner.ts
+++ b/functions/api/ccd006-citycoin-mining/get-block-winner.ts
@@ -1,22 +1,22 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const height = requestUrl.searchParams.get('height');
-  if (!height) return new Response('Missing height parameter', { status: 400 });
+  if (!height) return createResponse('Missing height parameter', 400);
 
   // get result from contract
   const blockWinner = await getBlockWinner(cityId, height);
 
   // return result
-  if (blockWinner === null) return new Response(`Block winner not found: ${cityId} ${height}`, { status: 404 });
-  return new Response(JSON.stringify(blockWinner));
+  if (blockWinner === null) return createResponse(`Block winner not found: ${cityId} ${height}`, 404);
+  return createResponse(blockWinner);
 }
 
 // returns the block winner for a given city ID and block height

--- a/functions/api/ccd006-citycoin-mining/get-coinbase-amount.ts
+++ b/functions/api/ccd006-citycoin-mining/get-coinbase-amount.ts
@@ -1,22 +1,22 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const height = requestUrl.searchParams.get('height');
-  if (!height) return new Response('Missing height parameter', { status: 400 });
+  if (!height) return createResponse('Missing height parameter', 400);
 
   // get result from contract
   const coinbaseAmount = await getCoinbaseAmount(cityId, height);
 
   // return result
-  if (!coinbaseAmount) return new Response(`Coinbase amount not found: ${cityId} ${height}`, { status: 404 });
-  return new Response(JSON.stringify(coinbaseAmount));
+  if (!coinbaseAmount) return createResponse(`Coinbase amount not found: ${cityId} ${height}`, 404);
+  return createResponse(coinbaseAmount);
 }
 
 // returns the coinbase amount for a given city ID and block height

--- a/functions/api/ccd006-citycoin-mining/get-high-value.ts
+++ b/functions/api/ccd006-citycoin-mining/get-high-value.ts
@@ -1,22 +1,22 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const height = requestUrl.searchParams.get('height');
-  if (!height) return new Response('Missing height parameter', { status: 400 });
+  if (!height) return createResponse('Missing height parameter', 400);
 
   // get result from contract
   const highValue = await getHighValue(cityId, height);
 
   // return result
-  if (!highValue) return new Response(`High value not found: ${cityId} ${height}`, { status: 404 });
-  return new Response(JSON.stringify(highValue));
+  if (!highValue) return createResponse(`High value not found: ${cityId} ${height}`, 404);
+  return createResponse(highValue);
 }
 
 // returns the high value for a given city ID and block height

--- a/functions/api/ccd006-citycoin-mining/get-miner.ts
+++ b/functions/api/ccd006-citycoin-mining/get-miner.ts
@@ -1,24 +1,24 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, Miner, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, Miner, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const height = requestUrl.searchParams.get('height');
-  if (!height) return new Response('Missing height parameter', { status: 400 });
+  if (!height) return createResponse('Missing height parameter', 400);
   const userId = requestUrl.searchParams.get('userId');
-  if (!userId) return new Response('Missing userId parameter', { status: 400 });
+  if (!userId) return createResponse('Missing userId parameter', 400);
 
   // get result from contract
   const miner = await getMiner(cityId, height, userId);
 
   // return result
-  if (!miner) return new Response(`Miner not found: ${cityId} ${height} ${userId}`, { status: 404 });
-  return new Response(JSON.stringify(miner));
+  if (!miner) return createResponse(`Miner not found: ${cityId} ${height} ${userId}`, 404);
+  return createResponse(miner);
 }
 
 // returns the miner for a given city ID, block height, and user ID

--- a/functions/api/ccd006-citycoin-mining/get-mining-stats.ts
+++ b/functions/api/ccd006-citycoin-mining/get-mining-stats.ts
@@ -1,22 +1,22 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, MiningStats, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, MiningStats, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const height = requestUrl.searchParams.get('height');
-  if (!height) return new Response('Missing height parameter', { status: 400 });
+  if (!height) return createResponse('Missing height parameter', 400);
 
   // get result from contract
   const miningStats = await getMiningStats(cityId, height);
 
   // return result
-  if (!miningStats) return new Response(`Mining stats not found: ${cityId} ${height}`, { status: 404 });
-  return new Response(JSON.stringify(miningStats));
+  if (!miningStats) return createResponse(`Mining stats not found: ${cityId} ${height}`, 404);
+  return createResponse(miningStats);
 }
 
 // returns the mining stats for a given city ID and block height

--- a/functions/api/ccd006-citycoin-mining/get-reward-delay.ts
+++ b/functions/api/ccd006-citycoin-mining/get-reward-delay.ts
@@ -1,5 +1,5 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
@@ -7,8 +7,8 @@ export async function onRequest(context: any): Promise<Response> {
   const rewardDelay = await getRewardDelay();
 
   // return result
-  if (!rewardDelay) return new Response(`Reward delay not found`, { status: 404 });
-  return new Response(JSON.stringify(rewardDelay));
+  if (!rewardDelay) return createResponse(`Reward delay not found`, 404);
+  return createResponse(rewardDelay);
 }
 
 // returns the reward delay

--- a/functions/api/ccd006-citycoin-mining/has-mined-at-block.ts
+++ b/functions/api/ccd006-citycoin-mining/has-mined-at-block.ts
@@ -17,13 +17,8 @@ export async function onRequest(context: any): Promise<Response> {
   const hasMined = await hasMinedAtBlock(cityId, height, userId);
 
   // return result
-<<<<<<< HEAD
-  if (hasMined === null) return new Response(`Miner not found: ${cityId} ${height} ${userId}`, { status: 404 });
-  return new Response(JSON.stringify(hasMined));
-=======
-  if (hasMined === undefined) return createResponse(`Miner not found: ${cityId} ${height} ${userId}`, 404);
+  if (hasMined === null) return createResponse(`Miner not found: ${cityId} ${height} ${userId}`, 404);
   return createResponse(hasMined);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the given user mined at the given block height

--- a/functions/api/ccd006-citycoin-mining/has-mined-at-block.ts
+++ b/functions/api/ccd006-citycoin-mining/has-mined-at-block.ts
@@ -34,7 +34,7 @@ async function hasMinedAtBlock(cityId: string, height: string, userId: string) {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd006-citycoin-mining/has-mined-at-block.ts
+++ b/functions/api/ccd006-citycoin-mining/has-mined-at-block.ts
@@ -1,24 +1,29 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const height = requestUrl.searchParams.get('height');
-  if (!height) return new Response('Missing height parameter', { status: 400 });
+  if (!height) return createResponse('Missing height parameter', 400);
   const userId = requestUrl.searchParams.get('userId');
-  if (!userId) return new Response('Missing userId parameter', { status: 400 });
+  if (!userId) return createResponse('Missing userId parameter', 400);
 
   // get result from contract
   const hasMined = await hasMinedAtBlock(cityId, height, userId);
 
   // return result
+<<<<<<< HEAD
   if (hasMined === null) return new Response(`Miner not found: ${cityId} ${height} ${userId}`, { status: 404 });
   return new Response(JSON.stringify(hasMined));
+=======
+  if (hasMined === undefined) return createResponse(`Miner not found: ${cityId} ${height} ${userId}`, 404);
+  return createResponse(hasMined);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the given user mined at the given block height

--- a/functions/api/ccd006-citycoin-mining/is-block-winner.ts
+++ b/functions/api/ccd006-citycoin-mining/is-block-winner.ts
@@ -7,18 +7,18 @@ export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const user = requestUrl.searchParams.get('user');
-  if (!user) return new Response('Missing user parameter', { status: 400 });
+  if (!user) return createResponse('Missing user parameter', 400);
   const claimHeight = requestUrl.searchParams.get('claimHeight');
-  if (!claimHeight) return new Response('Missing claimHeight parameter', { status: 400 });
+  if (!claimHeight) return createResponse('Missing claimHeight parameter', 400);
 
   // get result from contract
   const winner = await isBlockWinner(cityId, user, claimHeight);
 
   // return result
-  if (!winner) return new Response(`Block winner not found: ${cityId} ${user} ${claimHeight}`, { status: 404 });
-  return new Response(JSON.stringify(winner));
+  if (!winner) return createResponse(`Block winner not found: ${cityId} ${user} ${claimHeight}`, 404);
+  return createResponse(winner);
 }
 
 // returns true if the given user mined at the given block height

--- a/functions/api/ccd006-citycoin-mining/is-mining-enabled.ts
+++ b/functions/api/ccd006-citycoin-mining/is-mining-enabled.ts
@@ -7,13 +7,8 @@ export async function onRequest(context: any): Promise<Response> {
   const enabled = await isMiningEnabled();
 
   // return result
-<<<<<<< HEAD
-  if (enabled === null) return new Response(`Mining enabled status not found`, { status: 404 });
-  return new Response(JSON.stringify(enabled));
-=======
-  if (enabled === undefined) return createResponse(`Mining enabled status not found`, 404);
+  if (enabled === null) return createResponse(`Mining enabled status not found`, 404);
   return createResponse(enabled);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if mining is enabled

--- a/functions/api/ccd006-citycoin-mining/is-mining-enabled.ts
+++ b/functions/api/ccd006-citycoin-mining/is-mining-enabled.ts
@@ -1,5 +1,5 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
@@ -7,8 +7,13 @@ export async function onRequest(context: any): Promise<Response> {
   const enabled = await isMiningEnabled();
 
   // return result
+<<<<<<< HEAD
   if (enabled === null) return new Response(`Mining enabled status not found`, { status: 404 });
   return new Response(JSON.stringify(enabled));
+=======
+  if (enabled === undefined) return createResponse(`Mining enabled status not found`, 404);
+  return createResponse(enabled);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if mining is enabled

--- a/functions/api/ccd006-citycoin-mining/is-mining-enabled.ts
+++ b/functions/api/ccd006-citycoin-mining/is-mining-enabled.ts
@@ -24,7 +24,7 @@ async function isMiningEnabled() {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd007-citycoin-stacking/get-current-reward-cycle.ts
+++ b/functions/api/ccd007-citycoin-stacking/get-current-reward-cycle.ts
@@ -1,5 +1,5 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
@@ -7,8 +7,8 @@ export async function onRequest(context: any): Promise<Response> {
   const rewardCycle = await getCurrentRewardCycle();
 
   // return result
-  if (!rewardCycle) return new Response(`Reward cycle not found`, { status: 404 });
-  return new Response(JSON.stringify(rewardCycle));
+  if (!rewardCycle) return createResponse(`Reward cycle not found`, 404);
+  return createResponse(rewardCycle);
 }
 
 // returns the current reward cycle

--- a/functions/api/ccd007-citycoin-stacking/get-first-block-in-reward-cycle.ts
+++ b/functions/api/ccd007-citycoin-stacking/get-first-block-in-reward-cycle.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cycle = requestUrl.searchParams.get('cycle');
-  if (!cycle) return new Response('Missing cycle parameter', { status: 400 });
+  if (!cycle) return createResponse('Missing cycle parameter', 400);
 
   // get result from contract
   const firstBlockInRewardCycle = await getFirstBlockInRewardCycle(cycle);
 
   // return result
-  if (!firstBlockInRewardCycle) return new Response(`Reward cycle not found: ${cycle}`, { status: 404 });
-  return new Response(JSON.stringify(firstBlockInRewardCycle));
+  if (!firstBlockInRewardCycle) return createResponse(`Reward cycle not found: ${cycle}`, 404);
+  return createResponse(firstBlockInRewardCycle);
 }
 
 // returns the first block in a given reward cycle

--- a/functions/api/ccd007-citycoin-stacking/get-reward-cycle-length.ts
+++ b/functions/api/ccd007-citycoin-stacking/get-reward-cycle-length.ts
@@ -1,5 +1,5 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
@@ -7,8 +7,8 @@ export async function onRequest(context: any): Promise<Response> {
   const rewardCycleLength = await getRewardCycleLength();
 
   // return result
-  if (!rewardCycleLength) return new Response(`Reward cycle length not found`, { status: 404 });
-  return new Response(JSON.stringify(rewardCycleLength));
+  if (!rewardCycleLength) return createResponse(`Reward cycle length not found`, 404);
+  return createResponse(rewardCycleLength);
 }
 
 // returns the reward cycle length

--- a/functions/api/ccd007-citycoin-stacking/get-reward-cycle.ts
+++ b/functions/api/ccd007-citycoin-stacking/get-reward-cycle.ts
@@ -1,20 +1,20 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const burnHeight = requestUrl.searchParams.get('burnHeight');
-  if (!burnHeight) return new Response('Missing burnHeight parameter', { status: 400 });
+  if (!burnHeight) return createResponse('Missing burnHeight parameter', 400);
 
   // get result from contract
   const rewardCycle = await getRewardCycle(burnHeight);
 
   // return result
-  if (!rewardCycle) return new Response(`Reward cycle not found: ${burnHeight}`, { status: 404 });
-  return new Response(JSON.stringify(rewardCycle));
+  if (!rewardCycle) return createResponse(`Reward cycle not found: ${burnHeight}`, 404);
+  return createResponse(rewardCycle);
 }
 
 // returns the reward cycle for a given burn height

--- a/functions/api/ccd007-citycoin-stacking/get-stacker.ts
+++ b/functions/api/ccd007-citycoin-stacking/get-stacker.ts
@@ -1,24 +1,24 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK, Stacker } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK, Stacker } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const cycle = requestUrl.searchParams.get('cycle');
-  if (!cycle) return new Response('Missing cycle parameter', { status: 400 });
+  if (!cycle) return createResponse('Missing cycle parameter', 400);
   const userId = requestUrl.searchParams.get('userId');
-  if (!userId) return new Response('Missing userId parameter', { status: 400 });
+  if (!userId) return createResponse('Missing userId parameter', 400);
 
   // get result from contract
   const stacker = await getStacker(cityId, cycle, userId);
 
   // return result
-  if (!stacker) return new Response(`Stacker not found: ${cityId} ${cycle} ${userId}`, { status: 404 });
-  return new Response(JSON.stringify(stacker));
+  if (!stacker) return createResponse(`Stacker not found: ${cityId} ${cycle} ${userId}`, 404);
+  return createResponse(stacker);
 }
 
 // returns the stacker for a given cityId, cycle, and userId

--- a/functions/api/ccd007-citycoin-stacking/get-stacking-reward.ts
+++ b/functions/api/ccd007-citycoin-stacking/get-stacking-reward.ts
@@ -1,24 +1,24 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const cycle = requestUrl.searchParams.get('cycle');
-  if (!cycle) return new Response('Missing cycle parameter', { status: 400 });
+  if (!cycle) return createResponse('Missing cycle parameter', 400);
   const userId = requestUrl.searchParams.get('userId');
-  if (!userId) return new Response('Missing userId parameter', { status: 400 });
+  if (!userId) return createResponse('Missing userId parameter', 400);
 
   // get result from contract
   const reward = await getStackingReward(cityId, userId, cycle);
 
   // return result
-  if (!reward) return new Response(`Reward not found: ${cityId} ${cycle} ${userId}`, { status: 404 });
-  return new Response(JSON.stringify(reward));
+  if (!reward) return createResponse(`Reward not found: ${cityId} ${cycle} ${userId}`, 404);
+  return createResponse(reward);
 }
 
 async function getStackingReward(cityId: string, userId: string, cycle: string) {

--- a/functions/api/ccd007-citycoin-stacking/get-stacking-stats.ts
+++ b/functions/api/ccd007-citycoin-stacking/get-stacking-stats.ts
@@ -1,22 +1,22 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK, StackingStats } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK, StackingStats } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const cycle = requestUrl.searchParams.get('cycle');
-  if (!cycle) return new Response('Missing cycle parameter', { status: 400 });
+  if (!cycle) return createResponse('Missing cycle parameter', 400);
 
   // get result from contract
   const stackingStats = await getStackingStats(cityId, cycle);
 
   // return result
-  if (!stackingStats) return new Response(`Stacking stats not found: ${cityId} ${cycle}`, { status: 404 });
-  return new Response(JSON.stringify(stackingStats));
+  if (!stackingStats) return createResponse(`Stacking stats not found: ${cityId} ${cycle}`, 404);
+  return createResponse(stackingStats);
 }
 
 // returns the stacking stats for a given city and cycle

--- a/functions/api/ccd007-citycoin-stacking/is-cycle-paid.ts
+++ b/functions/api/ccd007-citycoin-stacking/is-cycle-paid.ts
@@ -32,7 +32,7 @@ async function isCyclePaid(cityId: string, cycle: string) {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd007-citycoin-stacking/is-cycle-paid.ts
+++ b/functions/api/ccd007-citycoin-stacking/is-cycle-paid.ts
@@ -1,22 +1,27 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const cycle = requestUrl.searchParams.get('cycle');
-  if (!cycle) return new Response('Missing cycle parameter', { status: 400 });
+  if (!cycle) return createResponse('Missing cycle parameter', 400);
 
   // get result from contract
   const paid = await isCyclePaid(cityId, cycle);
 
   // return result
+<<<<<<< HEAD
   if (paid === null) return new Response(`Cycle payout information not found: ${cityId} ${cycle}`, { status: 404 });
   return new Response(JSON.stringify(paid));
+=======
+  if (paid === undefined) return createResponse(`Cycle payout information not found: ${cityId} ${cycle}`, 404);
+  return createResponse(paid);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the cycle is paid

--- a/functions/api/ccd007-citycoin-stacking/is-cycle-paid.ts
+++ b/functions/api/ccd007-citycoin-stacking/is-cycle-paid.ts
@@ -15,13 +15,8 @@ export async function onRequest(context: any): Promise<Response> {
   const paid = await isCyclePaid(cityId, cycle);
 
   // return result
-<<<<<<< HEAD
-  if (paid === null) return new Response(`Cycle payout information not found: ${cityId} ${cycle}`, { status: 404 });
-  return new Response(JSON.stringify(paid));
-=======
-  if (paid === undefined) return createResponse(`Cycle payout information not found: ${cityId} ${cycle}`, 404);
+  if (paid === null) return createResponse(`Cycle payout information not found: ${cityId} ${cycle}`, 404);
   return createResponse(paid);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the cycle is paid

--- a/functions/api/ccd007-citycoin-stacking/is-stacking-active.ts
+++ b/functions/api/ccd007-citycoin-stacking/is-stacking-active.ts
@@ -16,13 +16,8 @@ export async function onRequest(context: any): Promise<Response> {
   const active = await isStackingActive(cityId, cycle);
 
   // return result
-<<<<<<< HEAD
-  if (active === null) return new Response(`Stacking status not found: ${cityId} ${cycle}`, { status: 404 });
-  return new Response(JSON.stringify(active));
-=======
-  if (active === undefined) return createResponse(`Stacking status not found: ${cityId} ${cycle}`, 404);
+  if (active === null) return createResponse(`Stacking status not found: ${cityId} ${cycle}`, 404);
   return createResponse(active);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the cycle is active

--- a/functions/api/ccd007-citycoin-stacking/is-stacking-active.ts
+++ b/functions/api/ccd007-citycoin-stacking/is-stacking-active.ts
@@ -33,7 +33,7 @@ async function isStackingActive(cityId: string, cycle: string) {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd007-citycoin-stacking/is-stacking-active.ts
+++ b/functions/api/ccd007-citycoin-stacking/is-stacking-active.ts
@@ -1,6 +1,6 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
 import { uintCV } from 'micro-stacks/clarity';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
@@ -8,16 +8,21 @@ export async function onRequest(context: any): Promise<Response> {
   // check query parameters
   const requestUrl = new URL(context.request.url);
   const cityId = requestUrl.searchParams.get('cityId');
-  if (!cityId) return new Response('Missing cityId parameter', { status: 400 });
+  if (!cityId) return createResponse('Missing cityId parameter', 400);
   const cycle = requestUrl.searchParams.get('cycle');
-  if (!cycle) return new Response('Missing cycle parameter', { status: 400 });
+  if (!cycle) return createResponse('Missing cycle parameter', 400);
 
   // get result from contract
   const active = await isStackingActive(cityId, cycle);
 
   // return result
+<<<<<<< HEAD
   if (active === null) return new Response(`Stacking status not found: ${cityId} ${cycle}`, { status: 404 });
   return new Response(JSON.stringify(active));
+=======
+  if (active === undefined) return createResponse(`Stacking status not found: ${cityId} ${cycle}`, 404);
+  return createResponse(active);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if the cycle is active

--- a/functions/api/ccd007-citycoin-stacking/is-stacking-enabled.ts
+++ b/functions/api/ccd007-citycoin-stacking/is-stacking-enabled.ts
@@ -7,13 +7,8 @@ export async function onRequest(context: any): Promise<Response> {
   const stackingEnabled = await isStackingEnabled();
 
   // return result
-<<<<<<< HEAD
-  if (stackingEnabled === null) return new Response(`Stacking status not found`, { status: 404 });
-  return new Response(JSON.stringify(stackingEnabled));
-=======
-  if (stackingEnabled === undefined) return createResponse(`Stacking status not found`, 404);
+  if (stackingEnabled === null) return createResponse(`Stacking status not found`, 404);
   return createResponse(stackingEnabled);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if stacking is enabled

--- a/functions/api/ccd007-citycoin-stacking/is-stacking-enabled.ts
+++ b/functions/api/ccd007-citycoin-stacking/is-stacking-enabled.ts
@@ -24,7 +24,7 @@ async function isStackingEnabled() {
       },
       true
     );
-    return Boolean(result);
+    return typeof result === 'boolean' ? Boolean(result) : null;
   } catch (err) {
     return null;
   }

--- a/functions/api/ccd007-citycoin-stacking/is-stacking-enabled.ts
+++ b/functions/api/ccd007-citycoin-stacking/is-stacking-enabled.ts
@@ -1,5 +1,5 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
@@ -7,8 +7,13 @@ export async function onRequest(context: any): Promise<Response> {
   const stackingEnabled = await isStackingEnabled();
 
   // return result
+<<<<<<< HEAD
   if (stackingEnabled === null) return new Response(`Stacking status not found`, { status: 404 });
   return new Response(JSON.stringify(stackingEnabled));
+=======
+  if (stackingEnabled === undefined) return createResponse(`Stacking status not found`, 404);
+  return createResponse(stackingEnabled);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns true if stacking is enabled

--- a/functions/api/ccd011-stacking-payouts/get-pool-operator.ts
+++ b/functions/api/ccd011-stacking-payouts/get-pool-operator.ts
@@ -7,13 +7,8 @@ export async function onRequest(context: any): Promise<Response> {
   const poolOperator = await getPoolOperator();
 
   // return result
-<<<<<<< HEAD
-  if (!poolOperator) return new Response(`Pool operator not found`, { status: 404 });
-  return new Response(poolOperator);
-=======
   if (!poolOperator) return createResponse(`Pool operator not found`, 404);
   return createResponse(poolOperator);
->>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns the pool operator

--- a/functions/api/ccd011-stacking-payouts/get-pool-operator.ts
+++ b/functions/api/ccd011-stacking-payouts/get-pool-operator.ts
@@ -1,5 +1,5 @@
 import { fetchReadOnlyFunction } from 'micro-stacks/api';
-import { DEPLOYER, NETWORK } from '../../../lib/api-helpers';
+import { createResponse, DEPLOYER, NETWORK } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
@@ -7,8 +7,13 @@ export async function onRequest(context: any): Promise<Response> {
   const poolOperator = await getPoolOperator();
 
   // return result
+<<<<<<< HEAD
   if (!poolOperator) return new Response(`Pool operator not found`, { status: 404 });
   return new Response(poolOperator);
+=======
+  if (!poolOperator) return createResponse(`Pool operator not found`, 404);
+  return createResponse(poolOperator);
+>>>>>>> 49f6024 (fix: use createResponse helper to generate resopnses)
 }
 
 // returns the pool operator

--- a/functions/api/stacks/get-block-height.ts
+++ b/functions/api/stacks/get-block-height.ts
@@ -1,4 +1,5 @@
 import { CoreNodeInfoResponse } from '@stacks/stacks-blockchain-api-types';
+import { createResponse } from '../../../lib/api-helpers';
 
 // TODO: upgrade types and check if EventContext is found
 export async function onRequest(context: any): Promise<Response> {
@@ -7,13 +8,14 @@ export async function onRequest(context: any): Promise<Response> {
     url.pathname = '/v2/info';
     const response = await fetch(url.toString());
     if (!response.ok) {
-      return new Response('Error fetching block height, please try again', { status: 500 });
+      return null;
     }
     const responseJson: CoreNodeInfoResponse = await response.json();
     return Number(responseJson.stacks_tip_height);
   };
 
+  // TODO: look at this approach again
   const currentBlockHeight = await blockHeight();
-
-  return new Response(JSON.stringify(currentBlockHeight));
+  if (currentBlockHeight === null) return createResponse('Error fetching block height, please try again', 500);
+  return createResponse(currentBlockHeight);
 }

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -1,5 +1,30 @@
 import { StacksMainnet, StacksTestnet } from 'micro-stacks/network';
 
+// General
+
+// TODO: there has to be a better way to do this
+type ResponseType =
+  | string
+  | number
+  | boolean
+  | GetCityInfo
+  | ActivationDetails
+  | GetCoinbaseInfo
+  | CoinbaseThresholds
+  | CoinbaseAmounts
+  | CoinbaseDetails
+  | MiningStats
+  | Miner
+  | BlockWinner
+  | StackingStats
+  | Stacker;
+
+export const createResponse = (data: ResponseType, status = 200): Response => {
+  return new Response(typeof data === 'string' ? data : JSON.stringify(data), { status: status });
+};
+
+// Stacks
+
 export const NETWORK = (network: string) => {
   switch (network) {
     case 'mainnet':


### PR DESCRIPTION
This will be useful later for implementing formats or special cases, and clearly defines the expected return types used in the same file. It also reduces the need for `JSON.stringify()` on every result that is not a string.

- fixes #6 
- fixes #7 